### PR TITLE
Improvements

### DIFF
--- a/dnevnik/class_unit.py
+++ b/dnevnik/class_unit.py
@@ -17,7 +17,7 @@ class ClassUnit:
     def __init__(self, client, class_unit_id: int):
         """
         Конструктор:
-        param client: Объект класса dnevnik.Client нужен для выолнения запросов
+        param client: Объект класса dnevnik.Client нужен для выполнения запросов
         param class_unit_id: id класса
         """
         self.__client = client

--- a/dnevnik/client.py
+++ b/dnevnik/client.py
@@ -67,7 +67,7 @@ class Client:
                           "t6281935149377429786 ",
             "Accept": "*/*"
         }
-        data = query_options
+        
         request = requests.get("https://dnevnik.mos.ru" + method, headers=parameters, params=query_options)
         if request.status_code in range(400, 500):
             print(request.content.decode("utf-8"))
@@ -100,8 +100,14 @@ class Client:
         param end_prepared_date: Указывает на то, по какое число нужно получить дз (По умолчанию сегодня)
         """
         homeworks = []
-        begin_prepared_date = datetime.today() if not begin_prepared_date else begin_prepared_date
-        end_prepared_date = datetime.today() if not end_prepared_date else end_prepared_date
+        
+        if not end_prepared_date and begin_prepared_date:
+            # Если указан только день с которого получать дз, но не указан по какой
+            end_prepared_date = begin_prepared_date
+        else:
+            begin_prepared_date = datetime.today() if not begin_prepared_date else begin_prepared_date
+            end_prepared_date = datetime.today() if not end_prepared_date else end_prepared_date
+
         homeworks_raw = self.make_request("/core/api/student_homeworks",
                                           begin_prepared_date=begin_prepared_date.strftime("%d.%m.%Y"),
                                           end_prepared_date=end_prepared_date.strftime("%d.%m.%Y"))
@@ -118,10 +124,16 @@ class Client:
         param date_from: Указывает с какого дня надо получить уроки (По умолчанию сегодня)
         param date_to: Указывает по какой день надо получить уроки (По умолчанию сегодня)
         """
-        if not date_to:
-            date_to = datetime.today()
+        
         if not date_from:
             date_from = datetime.today()
+        if not date_to:
+            if date_from:
+                # Если указан только день с которого получать уроки, но не указан по какой
+                date_to = date_from
+            else:
+                date_to = datetime.today()
+        
         lessons = self.make_request("/jersey/api/schedule_items",
                                     group_id=",".join(map(lambda gr: str(gr.id), self.profile.groups)),
                                     **{"from": date_from.strftime("%Y-%m-%d")}, to=date_to.strftime("%Y-%m-%d"),

--- a/dnevnik/client.py
+++ b/dnevnik/client.py
@@ -33,15 +33,18 @@ class Client:
         self.auth_token = auth_token
         self.profile_id = profile_id
         self.profile_index = profile_index
+
+        if self.auth_token and self.profile_id != 0:
+            pass
         # Логин через Selenium вместе с паролем и логином
-        if use_selenium and login and password:
+        elif use_selenium and login and password:
             from dnevnik.selenium_auth import SeleniumAuth
             self.selenium = SeleniumAuth(login, password, selenium_executable_path)
             self.auth_token = self.selenium.auth_token
             # Да, я знаю, это надо починить!!!
             self.profile_id = self.selenium.profile_id
         # Логин через реквесты (устаревший метод)
-        if login and password and not use_selenium:
+        elif login and password and not use_selenium:
             self.mos_ru_obj = MosRu(login, password)
             answer = self.mos_ru_obj.dnevnik_authorization()
             self.auth_token = answer["user_details"]["authentication_token"]

--- a/dnevnik/client.py
+++ b/dnevnik/client.py
@@ -48,8 +48,9 @@ class Client:
             if not profile_id:
                 self.profile_id = answer["user_details"]["profiles"][self.profile_index]["id"]
         print(f"[i] Auth-Token = {self.auth_token}\n[i] Profile-Id = {self.profile_id}")
+
     def make_request(self, method: str, raw=False, **query_options):
-        """ Позволяет сделать запрос с передачей всех необходимых параметровю. Дополнительные аргументы передаются как
+        """ Позволяет сделать запрос с передачей всех необходимых параметров. Дополнительные аргументы передаются как
             kwargs, параметр raw указывает на требования возврата без обработки модулем json, method позволяет указать
             метод API """
         parameters = {
@@ -85,7 +86,7 @@ class Client:
 
     @property
     def profile(self) -> StudentProfile:
-        """ Свойство, позволяет получить профиль пользователя """
+        """ Свойство позволяет получить профиль пользователя """
         return StudentProfile(self)
 
     def get_homeworks(self, begin_prepared_date: datetime = None, end_prepared_date: datetime = None) -> \

--- a/dnevnik/client.py
+++ b/dnevnik/client.py
@@ -34,8 +34,6 @@ class Client:
         self.profile_id = profile_id
         self.profile_index = profile_index
 
-        if self.auth_token and self.profile_id != 0:
-            pass
         # Логин через Selenium вместе с паролем и логином
         elif use_selenium and login and password:
             from dnevnik.selenium_auth import SeleniumAuth
@@ -100,13 +98,8 @@ class Client:
         param end_prepared_date: Указывает на то, по какое число нужно получить дз (По умолчанию сегодня)
         """
         homeworks = []
-        
-        if not end_prepared_date and begin_prepared_date:
-            # Если указан только день с которого получать дз, но не указан по какой
-            end_prepared_date = begin_prepared_date
-        else:
-            begin_prepared_date = datetime.today() if not begin_prepared_date else begin_prepared_date
-            end_prepared_date = datetime.today() if not end_prepared_date else end_prepared_date
+        begin_prepared_date = datetime.today() if not begin_prepared_date else begin_prepared_date
+        end_prepared_date = datetime.today() if not end_prepared_date else end_prepared_date
 
         homeworks_raw = self.make_request("/core/api/student_homeworks",
                                           begin_prepared_date=begin_prepared_date.strftime("%d.%m.%Y"),
@@ -125,14 +118,8 @@ class Client:
         param date_to: Указывает по какой день надо получить уроки (По умолчанию сегодня)
         """
         
-        if not date_from:
-            date_from = datetime.today()
-        if not date_to:
-            if date_from:
-                # Если указан только день с которого получать уроки, но не указан по какой
-                date_to = date_from
-            else:
-                date_to = datetime.today()
+        date_from = datetime.today() if not date_from else date_from
+        date_to = datetime.today() if not date_to else date_to
         
         lessons = self.make_request("/jersey/api/schedule_items",
                                     group_id=",".join(map(lambda gr: str(gr.id), self.profile.groups)),

--- a/dnevnik/student_profile.py
+++ b/dnevnik/student_profile.py
@@ -54,17 +54,17 @@ class StudentProfile:
 
     @property
     def class_unit(self):
-        """ Свойство, используется для получение объекта Class Unit """
+        """ Свойство используется для получение объекта Class Unit """
         return ClassUnit(self.__client, class_unit_id=self.__class_unit_id)
 
     @property
     def school(self):
-        """ Свойство, используется дл получения объекта School """
+        """ Свойство используется для получения объекта School """
         return School(self.__client, school_id=self.__school_id)
 
     @property
     def groups(self):
-        """ Свойство, для получения групп, в которых состоит учащийся """
+        """ Свойство для получения групп, в которых состоит учащийся """
         groups_list = []
         for group in self.__groups_list:
             del group["subgroup_ids"]


### PR DESCRIPTION
* Исправлены опечатки 
* Добавлена возможность прозводить авторизацию используя только `auth_token` и `profile_id` (без Selenium или requests)
* В `get_homeworks` и `get_lessons` исправлена ошибка из-за которой нельзя было выбрать дату с которой производить отсчет и не указывать дату окончания.

```py
if not date_from:
    date_from = datetime.today()
if not date_to:
    if date_from:
        # Если указана дата начала, но не указана дата окончания, то прировнять дату начала и 
        # окончания, чтобы получить ответ от сервера для одного дня. 
        # Если это не сделать то ответ будет некорректный. Так как дата начала может быть в будущем, 
        # а дата окончания будет равна текущему дню. 
        date_to = date_from
    else:
        date_to = datetime.today()
```