### PR TITLE
Add Inject to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         'selenium',
         'bs4',
         'lxml',
-        'pydantic'
+        'pydantic',
+        'Inject'
     ]
 )


### PR DESCRIPTION
Из-за того что Inject не был добавлен в install_requires, он не скачивался pip-ом и возникали ошибки парсинга.

`AttributeError: module 'dnevnik' has no attribute 'Client'`
`Error, while module parsing`